### PR TITLE
Call BaseFlickrAPI constructor directly

### DIFF
--- a/django_flickr_gallery/base.py
+++ b/django_flickr_gallery/base.py
@@ -24,7 +24,7 @@ class FlickrAPI(BaseFlickrAPI):
     """
     def __new__(cls, *args, **kwargs):
         if not hasattr(cls, '_flickr_api_instance'):
-            cls._flickr_api_instance = super(FlickrAPI, cls).__new__(cls, *args, **kwargs)
+            cls._flickr_api_instance = BaseFlickrAPI(*args, **kwargs)
         return cls._flickr_api_instance
 
     @staticmethod


### PR DESCRIPTION
The class `BaseFlickrAPI` doesn't have its own `__new__` method, so this was failing as the `super` was delegating the method call down to `object` and therefore raising the error `object() takes no parameters`.